### PR TITLE
给markdown最后自动添加译者信息

### DIFF
--- a/pages/src/content/config.ts
+++ b/pages/src/content/config.ts
@@ -16,6 +16,10 @@ const blog = defineCollection({
       [z.date(), z.string(), z.number()]
     ).default(""),
     link: z.string().url().default(""),
+    proofreader: z.string().default(SITE.author),
+    proofread_date: z.union(
+      [z.date(), z.string(), z.number()]
+    ).default(""),
   }),
 });
 

--- a/pages/src/content/config.ts
+++ b/pages/src/content/config.ts
@@ -20,6 +20,10 @@ const blog = defineCollection({
     proofread_date: z.union(
       [z.date(), z.string(), z.number()]
     ).default(""),
+    publisher: z.string().default(SITE.author),
+    published_date: z.union(
+      [z.date(), z.string(), z.number()]
+    ).default(""),
   }),
 });
 

--- a/pages/src/layouts/PostDetails.astro
+++ b/pages/src/layouts/PostDetails.astro
@@ -13,7 +13,7 @@ export interface Props {
 
 const { post } = Astro.props;
 
-const { title, author, collected_date, collector, translated_date, translator, link, proofreader, proofread_date } = post.data;
+const { title, author, collected_date, collector, translated_date, translator, link, proofreader, proofread_date, publisher, published_date } = post.data;
 
 const { Content } = await post.render();
 
@@ -62,30 +62,32 @@ const layoutProps = {
       <Content />
       <hr>
       <div>
-        <!-- if there is translated_date, show below -->
-        {
-          translated_date && (
-            <p><strong>译自：</strong> <a href="{link}">{link}</a></p>
-            <p>
+        <p><strong>{!translated_date ? "原文链接：": "译自："}</strong> <a href={link}>{link}</a></p>
+        <p>
+          <strong>选题：</strong>
+          <a href={"https://github/" + collector}>{collector}</a>
+          {translated_date && (
+            <span>
+              &nbsp;&nbsp;
               <strong>译者：</strong> 
               <a href={"https://github/" + translator}>{translator}</a>
-              {
-                proofread_date && (
+              {proofread_date && (
+                <span>
+                  &nbsp;&nbsp;
                   <strong>校对：</strong><a href={"https://github/" + proofreader}>{proofreader}</a>
-                  <p>本文由<a href="https://gitee.com/hust-open-atom-club/translate-project">HCTT</a>原创翻译，<a href="https://gitee.com/hust-open-atom-club">华科开放原子俱乐部</a>荣誉推出。</p>
-                )
-              }
-            </p>
-          )
-        }
-        <!-- if there is not translated_date, show below -->
-        {
-          !translated_date && (
-            <p><strong>原文链接：</strong> <a href="{link}">{link}</a></p>
-          )
-        }
-        
-      </div>
+                </span>
+              )}
+              {published_date && (
+                <span>
+                  &nbsp;&nbsp;
+                  <strong>发布：</strong><a href={"https://github/" + publisher}>{publisher}</a>
+                </span>
+              )}
+            </span>
+          )}
+        </p>
+        <p>本文{!translated_date && "将"}由 <a href="https://gitee.com/hust-open-atom-club/translate-project">HCTT 翻译团队</a> 原创翻译，<a href="https://gitee.com/hust-open-atom-club">华中科技大学开放原子开源俱乐部</a>荣誉推出。</p>
+      </div>      
     </article>
 
     <!-- <ul class="my-8"> -->

--- a/pages/src/layouts/PostDetails.astro
+++ b/pages/src/layouts/PostDetails.astro
@@ -13,7 +13,7 @@ export interface Props {
 
 const { post } = Astro.props;
 
-const { title, author } = post.data;
+const { title, author, collected_date, collector, translated_date, translator, link, proofreader, proofread_date } = post.data;
 
 const { Content } = await post.render();
 
@@ -60,6 +60,32 @@ const layoutProps = {
     <!-- /> -->
     <article id="article" role="article" class="prose mx-auto mt-8 max-w-3xl">
       <Content />
+      <hr>
+      <div>
+        <!-- if there is translated_date, show below -->
+        {
+          translated_date && (
+            <p><strong>译自：</strong> <a href="{link}">{link}</a></p>
+            <p>
+              <strong>译者：</strong> 
+              <a href={"https://github/" + translator}>{translator}</a>
+              {
+                proofread_date && (
+                  <strong>校对：</strong><a href={"https://github/" + proofreader}>{proofreader}</a>
+                  <p>本文由<a href="https://gitee.com/hust-open-atom-club/translate-project">HCTT</a>原创翻译，<a href="https://gitee.com/hust-open-atom-club">华科开放原子俱乐部</a>荣誉推出。</p>
+                )
+              }
+            </p>
+          )
+        }
+        <!-- if there is not translated_date, show below -->
+        {
+          !translated_date && (
+            <p><strong>原文链接：</strong> <a href="{link}">{link}</a></p>
+          )
+        }
+        
+      </div>
     </article>
 
     <!-- <ul class="my-8"> -->
@@ -68,7 +94,7 @@ const layoutProps = {
 
     <div
       class="my-8 flex flex-col-reverse items-center justify-between gap-6 sm:flex-row-reverse sm:items-end sm:gap-4"
-    >
+    >    
       <button
         id="back-to-top"
         class="focus-outline whitespace-nowrap py-1 hover:opacity-75"

--- a/sources/general/20240223 linux is a CNA.md
+++ b/sources/general/20240223 linux is a CNA.md
@@ -24,11 +24,3 @@ CVE 组织[最近宣布](https://www.cve.org/Media/News/item/news/2024/02/13/ker
 您可以在此[邮件列表](https://lore.kernel.org/linux-cve-announce/)上找到我们分配的所有 CVE，并且如果您希望自动收到所有 CVE 的通知，请订阅该列表。可以在[此处](https://git.kernel.org/pub/scm/linux/security/vulns.git/)找到它们的 git 存储库，但请注意，随着时间的推移，存储库的结构会发生变化，因为我们在学习和管理流程方面会变得更加完善，所以暂时不要认为 git 树中的任何内容会固定不变。
 
 一旦流程正常运转并且能够顺利分配 CVE，我会在未来写更多内容。这一公告只是第一步，它使我们成为了 Linux CVE 分配流程的管理者。
-
-___
-
-译自：<http://www.kroah.com/log/blog/2024/02/13/linux-is-a-cna/>
-
-译者：[sun-yu-777](https://gitee.com/sun-yu-777) 校对：[mudongliang](https://gitee.com/mudongliang)
-
-本文由[HCTT](https://gitee.com/hust-open-atom-club/translate-project)原创翻译，[华科开放原子俱乐部](https://gitee.com/hust-open-atom-club)荣誉推出。

--- a/sources/kernel/20240220 linux kernel CVE assignment.md
+++ b/sources/kernel/20240220 linux kernel CVE assignment.md
@@ -52,11 +52,3 @@ Linux内核中未修复的安全问题不会自动分配CVE；只有在安全修
 简而言之，我们不知道您的用例，也不知道您使用的是内核的哪个部分，因此我们无法确定特定的CVE是否与您的系统相关。
 
 与往常一样，最好采取所有发布的内核更改，因为它们是由许多社区成员在一个统一的整体中一起进行测试的，而不是作为个别的精选更改。还要注意，对于许多bug来说，整体问题的解决方案并不是在单个更改中找到的，而是在彼此之上的许多修复的总和。理想情况下，CVEs将被分配给所有问题的所有修复，但有时我们将无法注意到一些修复，因此某些修复可能在没有CVE的情况下被采取。
-
-___
-
-译自：<https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/cve.rst>
-
-译者：[yanruo](https://gitee.com/kyanruo) 校对：[mudongliang](https://gitee.com/mudongliang)
-
-本文由[HCTT](https://gitee.com/hust-open-atom-club/translate-project)原创翻译，[华科开放原子俱乐部](https://gitee.com/hust-open-atom-club)荣誉推出。

--- a/sources/kernel/20240227 Undefined Behavior Sanitizer - UBSAN.md
+++ b/sources/kernel/20240227 Undefined Behavior Sanitizer - UBSAN.md
@@ -78,10 +78,3 @@ GCC 自 4.9.x \[[1](https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Debugging-Optio
     UBSAN_SANITIZE := n
 
 未对齐的内存访问检测由单独的选项 CONFIG_UBSAN_ALIGNMENT 控制。在支持非对齐访问（CONFIG_HAVE_EFFICIENT_UNALIGNED_ACCESS=y）的架构上，该选项默认关闭，但仍可在配置中启用，只是要注意这会产生大量 UBSAN 报告。
-
----
-译自：<https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/dev-tools/ubsan.rst>
-
-译者：[dzm91_hust](https://gitee.com/dzm91_hust) 校对：[hustsjy](https://gitee.com/hustsjy)
-
-本文由[HCTT](https://gitee.com/hust-open-atom-club/translate-project)原创翻译，[华科开放原子俱乐部](https://gitee.com/hust-open-atom-club)荣誉推出。

--- a/sources/syzkaller/executing_syzkaller_programs.md
+++ b/sources/syzkaller/executing_syzkaller_programs.md
@@ -73,10 +73,3 @@ scp -P 10022 -i bullseye.img.key bin/linux_amd64/syz-execprog bin/linux_amd64/sy
 # {Threaded:true Repeat:true RepeatTimes:0 Procs:8 Slowdown:1 Sandbox:none Leak:false NetInjection:true NetDevices:true NetReset:true Cgroups:true BinfmtMisc:true CloseFDs:true KCSAN:false DevlinkPCI:false USB:true VhciInjection:true Wifi:true IEEE802154:true Sysctl:true UseTmpDir:true HandleSegv:true Repro:false Trace:false LegacyOptions:{Collide:false Fault:false FaultCall:0 FaultNth:0}}
 ```
 你需要基于文件头中的值调整对应的参数。其中，`Threaded`/`Procs`/`Sandbox` 与 `-threaded`/`-procs`/`-sandbox` 参数对应。如果 `Repeat` 的值为 `true`，则在 `syz-execprog` 的参数中添加 `-repeat=0`。
-
----
-译自：<https://github.com/google/syzkaller/blob/master/docs/executing_syzkaller_programs.md>
-
-译者：[tttturtle-russ](https://gitee.com/tttturtle-russ) 校对：[dzm91_hust](https://gitee.com/dzm91_hust)
-
-本文由[HCTT](https://gitee.com/hust-open-atom-club/translate-project)原创翻译，[华科开放原子俱乐部](https://gitee.com/hust-open-atom-club)荣誉推出。


### PR DESCRIPTION
fix https://github.com/hust-open-atom-club/TranslateProject/issues/8
解决结果：
已经发布的会显示如下：
![image](https://github.com/hust-open-atom-club/TranslateProject/assets/58585665/39c46442-abb4-4917-a76a-c99c88db1b5d)
没发布的显示：
![image](https://github.com/hust-open-atom-club/TranslateProject/assets/58585665/656cb515-7700-429a-9156-567a4baba43d)
没翻译的显示：
![image](https://github.com/hust-open-atom-club/TranslateProject/assets/58585665/a07a77ed-a504-42d8-9791-afbc5b710f58)
