### PR TITLE
sjy fix typo in UBSAN

### DIFF
--- a/sources/kernel/20240227 Undefined Behavior Sanitizer - UBSAN.md
+++ b/sources/kernel/20240227 Undefined Behavior Sanitizer - UBSAN.md
@@ -4,9 +4,9 @@ title: "Undefined Behavior Sanitizer - UBSAN"
 author: Linux Kernel Community
 collector: mudongliang
 collected_date: 20240227
-translated: mudongliang
+translator: mudongliang
 translated_date: 20240227
-proofread: JingJing1016
+proofreader: JingJing1016
 proofread_date: 20240302
 link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/Documentation/dev-tools/ubsan.rst
 ---


### PR DESCRIPTION
由于笔误导致自动生成的翻译人员，校对人员显示为 [HCTT](https://github.com/HCTT)（因为SITE.author是HCTT，但这个账号实际上不存在）