### PR TITLE
posts: 增加简介解析成Markdown的功能。

### DIFF
--- a/pages/package-lock.json
+++ b/pages/package-lock.json
@@ -16,6 +16,7 @@
         "astro-rehype-relative-markdown-links": "^0.6.1",
         "fuse.js": "^7.0.0",
         "github-slugger": "^2.0.0",
+        "html-truncator": "^1.0.17",
         "marked": "^13.0.2",
         "remark-collapse": "^0.1.2",
         "remark-toc": "^9.0.0",
@@ -5863,7 +5864,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dev": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -5877,7 +5877,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5889,7 +5888,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dev": true,
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -5904,7 +5902,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
       "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-      "dev": true,
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -7686,6 +7683,35 @@
         "node": "^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/html-truncator": {
+      "version": "1.0.17",
+      "resolved": "https://mirrors.huaweicloud.com/repository/npm/html-truncator/-/html-truncator-1.0.17.tgz",
+      "integrity": "sha512-qa4vQJUGH4oZqdbAxsT4RG+PbBiVJHyPrvXI1P7FQegsxvuxozdAgxq5msPXzYD56JjO+nRh37mob6svIxBcDw==",
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^8.0.2",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/html-truncator/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://mirrors.huaweicloud.com/repository/npm/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -9127,8 +9153,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",

--- a/pages/package-lock.json
+++ b/pages/package-lock.json
@@ -16,6 +16,7 @@
         "astro-rehype-relative-markdown-links": "^0.6.1",
         "fuse.js": "^7.0.0",
         "github-slugger": "^2.0.0",
+        "marked": "^13.0.2",
         "remark-collapse": "^0.1.2",
         "remark-toc": "^9.0.0",
         "satori": "^0.10.11",
@@ -9457,6 +9458,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "13.0.2",
+      "resolved": "https://mirrors.huaweicloud.com/repository/npm/marked/-/marked-13.0.2.tgz",
+      "integrity": "sha512-J6CPjP8pS5sgrRqxVRvkCIkZ6MFdRIjDkwUwgJ9nL2fbmM6qGQeB2C16hi8Cc9BOzj6xXzy0jyi0iPIfnMHYzA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mdast-util-definitions": {

--- a/pages/package.json
+++ b/pages/package.json
@@ -22,6 +22,7 @@
     "astro-rehype-relative-markdown-links": "^0.6.1",
     "fuse.js": "^7.0.0",
     "github-slugger": "^2.0.0",
+    "marked": "^13.0.2",
     "remark-collapse": "^0.1.2",
     "remark-toc": "^9.0.0",
     "satori": "^0.10.11",

--- a/pages/package.json
+++ b/pages/package.json
@@ -22,6 +22,7 @@
     "astro-rehype-relative-markdown-links": "^0.6.1",
     "fuse.js": "^7.0.0",
     "github-slugger": "^2.0.0",
+    "html-truncator": "^1.0.17",
     "marked": "^13.0.2",
     "remark-collapse": "^0.1.2",
     "remark-toc": "^9.0.0",

--- a/pages/src/components/Card.tsx
+++ b/pages/src/components/Card.tsx
@@ -1,6 +1,19 @@
 import { STATUS_LIST } from "@config";
 import { slugifyStr } from "@utils/slugify";
 import type { CollectionEntry } from "astro:content";
+import { marked } from 'marked';
+
+// 定义一个函数，解析body为markdown格式，然后去掉解析出来的所有h标签元素
+const parseBody = (body: string) =>  {
+  let marked_content = marked(body.substring(0, 1000)); // 避免过长的解析
+  // check type of marked_content
+  if (typeof marked_content !== 'string') {
+    return body.substring(0, 130) + '……&nbsp&nbsp';
+  }
+  // remove h1
+  marked_content = marked_content.replace(/<h..*?>.*?<\/h.>/g, '');
+  return marked_content.substring(0, 130) + '……&nbsp&nbsp';
+}
 
 export interface Props {
   id?: string;
@@ -60,10 +73,13 @@ export default function Card({ id, href, frontmatter, secHeading = true, body, p
         {/* <Datetime pubDatetime={pubDatetime} modDatetime={modDatetime} /> */}
       </div>
       {publishCard &&
-        <p className="break-all">
-          <span className="mr-2">{body?.replace("#", "")?.substring(0, 130)}</span>
-          <a href={href} className="text-orange">[阅读更多]</a>
-        </p>
+        <div className="break-all prose">
+          {/* 解析body为markdown格式，然后去掉解析出来的所有h1标签元素，然后将所有段落解析成自然段<p> */}
+          <span className="mr-2" dangerouslySetInnerHTML={{
+            __html: parseBody(body || "") }} >
+              </span>
+          <a href={href}>[阅读更多]</a>
+        </div>
       }
     </li>
   );


### PR DESCRIPTION
去掉了正文中的一级标题和图片，让简介更像个简介。另外Markdown也正常解析。
1. 参考[astro官方说明](https://docs.astro.build/zh-cn/guides/markdown-content/#%E8%AF%B7%E6%B1%82%E8%BF%9C%E7%A8%8B-markdown)需要调用marked库，因为astro的markdown本地解析只针对md或mdx文件而不针对字符串。
2. 对于简介的文本限长额外引入了分隔库html-truncator保证解析结果的html标签闭合。


![image](https://github.com/hust-open-atom-club/TranslateProject/assets/58585665/3f1f4748-f5f1-4bb2-9291-7813bd0a6a3b)

![image](https://github.com/hust-open-atom-club/TranslateProject/assets/58585665/ce4ef4c0-2de3-43bd-b253-89aa4b297022)

![image](https://github.com/hust-open-atom-club/TranslateProject/assets/58585665/4425a6cf-6c1f-4573-a86f-a8ca86b8b447)
