### PR TITLE
add scripts for checking the file to be pushed to syzkaller upstream

### DIFF
--- a/.scripts/check_for_syzkaller.sh
+++ b/.scripts/check_for_syzkaller.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Created by QGrain in 2024/07/15
+
+# Usage:
+# 1) check all of the markdown files under sources/syzkaller/:
+#    $ ./check_for_syzkaller.sh
+# 2) check one specified markdown file though the first param:
+#    $ ./check_for_syzkaller.sh sources/syzkaller/syscall_descriptions_syntax.md
+
+check_whitespace() {
+    FILES=0
+	FAILED=""
+	RE="[[:space:]]$"
+	LAST_EMPTY=""
+    if [[ $1 ]]; then
+        file_list="$1"
+    else
+        file_list=$(find . -name "*.md" | grep "syzkaller/")
+    fi
+	for F in $file_list; do
+		((FILES+=1))
+		L=0
+		while IFS= read -r LINE; do
+			((L+=1))
+			if [[ $LINE =~ $RE ]]; then
+				echo "$F:$L:1: Trailing whitespace at the end of the line. Please remove."
+				echo "$LINE"
+				FAILED="1"
+			fi
+			LAST_EMPTY=""
+			if [ "$LINE" == "" ]; then
+				LAST_EMPTY="1"
+			fi
+		done < "$F"
+		if [ "$LAST_EMPTY" != "" ]; then
+			echo "$F:$L:1: Trailing empty line at the end of the file. Please remove."
+			FAILED="1"
+		fi
+	done
+	if [ "$FAILED" != "" ]; then
+		echo -e "❌ check_whitespace failed. Please fix the lines shown above."
+		return 1
+	else
+		echo -e "✅ check_whitespace passed."
+		return 0
+	fi
+}
+
+
+check_language() {
+	FILES=0
+	FAILED=""
+	shopt -s nocasematch
+    if [[ $1 ]]; then
+        file_list="$1"
+    else
+        file_list=$(find . -name "*.md" | grep "syzkaller/")
+    fi
+	for F in $file_list; do
+		((FILES+=1))
+		L=0
+		while IFS= read -r LINE; do
+			((L+=1))
+			if [[ $LINE =~ (slave|blacklist|whitelist) ]]; then
+				if [[ $LINE =~ bond_enslave ]]; then
+					continue
+				fi
+				SUGGESTIONS="block/allow/ignore/skip"
+				if [[ $LINE =~ (slave) ]]; then
+					SUGGESTIONS="leader/follower/coordinator/worker/parent/helper"
+				fi
+				echo "$F:$L:1: Please use more respectful terminology, consider using ${SUGGESTIONS} instead." \
+					"See https://tools.ietf.org/id/draft-knodel-terminology-01.html for more info."
+				echo "$LINE"
+				FAILED="1"
+			fi
+		done < "$F"
+	done
+	if [ "$FAILED" != "" ]; then
+		echo -e "❌ check_language failed. There may be some offensive or illegal words in the lines shown above."
+		return 1
+	else
+		echo -e "✅ check_language passed."
+		return 0
+	fi
+}
+
+
+script_dir=$(dirname $0)
+ERROR=""
+
+
+check_whitespace $1
+if [[ $? != 0 ]]; then
+    ERROR="1"
+    echo -e "whitespace failed: $ERROR"
+fi
+
+
+check_language $1
+if [[ $? != 0 ]]; then
+    ERROR="1"
+fi
+
+if [[ $1 ]]; then
+    file_list="$1"
+else
+    file_list=$(find . -name "*.md" | grep "syzkaller/")
+fi
+python3 $script_dir/check_links.py ~/fuzzers/syzkaller-fork/ $file_list
+if [[ $? == 0 ]]; then
+    echo -e "✅ check_links passed."
+else
+    echo -e "❌ check_links failed."
+    ERROR="1"
+fi
+
+if [ "$ERROR" != "" ]; then
+    echo -e "[Summary] some checks failed. It cannot be pushed to syzkaller upstream"
+    exit 1
+else
+    echo -e "[Summary] all checks passed. It can be pushed to syzkaller upstream now."
+    exit 0
+fi

--- a/.scripts/check_links.py
+++ b/.scripts/check_links.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# Copyright 2017 syzkaller project authors. All rights reserved.
+# Use of this source code is governed by Apache 2 LICENSE that can be found in the LICENSE file.
+# Modified by QGrain in 2024/07/15
+
+from __future__ import print_function
+import os
+import re
+import sys
+
+link_re = re.compile('\[' + '[^\[\]]+' + '\]' + '\(' + '([^\(\)]+)' + '\)')
+
+if len(sys.argv) < 3:
+	print('Usage: <root_dir> <doc_files>...')
+	sys.exit(1)
+
+root = sys.argv[1]
+docs = sys.argv[2:]
+
+links = []
+
+for doc in docs:
+	syzkaller_doc = doc.replace('sources/syzkaller/', 'docs/')
+	with open(doc) as f:
+		for i, line in enumerate(f.readlines()):
+			for match in link_re.finditer(line):
+				links += [(syzkaller_doc, match.group(1), i + 1, match.start(1))]
+
+errors = []
+
+# # absolute link is acceptable?
+# for link in links:
+# 	(syzkaller_doc, link, line, col) = link
+# 	doc = syzkaller_doc.replace('docs/', 'sources/syzkaller/')
+# 	for prefix in ['https://github.com/google/syzkaller/blob/master', 'https://github.com/google/syzkaller/tree/master']:
+# 		if link.startswith(prefix):
+# 			errors += ['%s:%d:%d: Replace absolute link with %s.' % (doc, line, col, link[len(prefix):])]
+
+def filter_link(args):
+	(doc, link, line, col) = args
+	if link.startswith('http'):
+		return False
+	if link.startswith('#'):
+		return False
+	if link.startswith('mailto'):
+		return False
+	return True
+
+links = list(filter(filter_link, links))
+
+def fix_link(args):
+	(doc, link, line, col) = args
+	link = link.split('#')[0]
+	link = link.split('?')[0]
+	return (doc, link, line, col)
+
+links = list(map(fix_link, links))
+
+def check_link(args):
+	(doc, link, line, col) = args
+	path = os.path.dirname(doc)
+	full_link = None
+	if link[0] == '/':
+		link = link[1:]
+		full_link = os.path.join(root, link)
+	else:
+		full_link = os.path.join(root, path, link)
+	if not os.path.exists(full_link):
+		return False
+	return True
+
+for link in links:
+	if not check_link(link):
+		(syzkaller_doc, link, line, col) = link
+		doc = syzkaller_doc.replace('docs/', 'sources/syzkaller/')
+		errors += ['%s:%d:%d: Broken link %s.' % (doc, line, col, link)]
+
+if len(errors) == 0:
+	# print('%d links checked: OK' % len(links))
+	sys.exit(0)
+
+for error in errors:
+	print(error)
+
+sys.exit(2)


### PR DESCRIPTION
For translated files under `sources/syzkaller/`, they need to pass at least these checks before they can be pushed upstream to syzkaller.

Usage:
1. check all of the markdown files under `sources/syzkaller/`:
```bash
./check_for_syzkaller.sh
```
2. check one specified markdown file though the first param:
```bash
./check_for_syzkaller.sh sources/syzkaller/syscall_descriptions_syntax.md # e.g.
```