### PR TITLE
fix(pages): 将已发布文章的时间排序代码挪到分页之前，解决分页后未排序的问题。

### DIFF
--- a/pages/src/layouts/Posts.astro
+++ b/pages/src/layouts/Posts.astro
@@ -61,13 +61,7 @@ const countData = getStatusCount(await getCollection("posts"));
     }
     <ul>
       {
-        // sort by date
-        paginatedPosts.sort((a, b) => {
-          // 假设 published_date 是字符串形式如 '20240428'
-          const dateA = parseInt(a.data.published_date.toString());
-          const dateB = parseInt(b.data.published_date.toString());
-          return dateB - dateA; // 降序排列，若需升序改为 dateA - dateB
-        }).map(({ id, data, slug, body }) => (
+        paginatedPosts.map(({ id, data, slug, body }) => (
           <Card
             id={id}
             href={`/posts/${slug}/`}

--- a/pages/src/utils/getSortedPosts.ts
+++ b/pages/src/utils/getSortedPosts.ts
@@ -1,9 +1,17 @@
 import type { CollectionEntry } from "astro:content";
 
 const getSortedPosts = (posts: CollectionEntry<"posts">[]) => {
-  return posts;
-
     // TODO: implement sorting
+
+    // split all the posts by its status
+    const publishedPosts = posts.filter((post) => post.data.status === "published");
+    const otherPosts = posts.filter((post) => post.data.status !== "published");
+    // sort the published posts by its published date
+    publishedPosts.sort((a: CollectionEntry<"posts">, b: CollectionEntry<"posts">) => {
+      return new Date(b.data.published_date).getTime() - new Date(a.data.published_date).getTime();
+    });
+    // combine the sorted published posts with the other posts
+    posts = publishedPosts.concat(otherPosts);
 
     // .sort(
     //   (a, b) =>
@@ -14,6 +22,8 @@ const getSortedPosts = (posts: CollectionEntry<"posts">[]) => {
     //       new Date(a.data.modDatetime ?? a.data.pubDatetime).getTime() / 1000
     //     )
     // );
+
+    return posts;
 };
 
 export default getSortedPosts;


### PR DESCRIPTION
主要是挪了一下排序的代码的位置。之前加得太靠后了。

![image](https://github.com/user-attachments/assets/101ce4c0-af8d-4e12-9e0d-d3fa8c517231)
![image](https://github.com/user-attachments/assets/1831a125-588d-4c04-a7d1-2c3787cd47a2)
