### PR TITLE
fix: 修复"阅读更多"链接渲染

### DIFF
--- a/pages/src/components/Card.tsx
+++ b/pages/src/components/Card.tsx
@@ -25,7 +25,7 @@ const parseBody = (body: string, href: string) => {
   let lastTagContent = marked_content.substring(lastTag);
   // remove the last tag
   marked_content = marked_content.substring(0, lastTag);
-  let end = "……&nbsp&nbsp<a href={" + href + "}>[阅读更多]</a>" + lastTagContent;
+  let end = "……&nbsp&nbsp<a href=" + href + ">[阅读更多]</a>" + lastTagContent;
   return marked_content + end;
 }
 


### PR DESCRIPTION
[阅读更多]按钮链接渲染多了一对大括号（%7B）导致404
修复前：
![image](https://github.com/user-attachments/assets/fbc998f4-6d03-4982-b85c-e4f032293554)
