### PR TITLE
feat(ci): lint all Markdown files

### DIFF
--- a/.github/workflows/lint-all.yaml
+++ b/.github/workflows/lint-all.yaml
@@ -1,0 +1,50 @@
+name: Lint All
+
+on:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install zhlint
+        run: yarn global add zhlint
+
+      - name: Lint all Markdown files
+        run: |
+          mkdir -p linted_output
+          file_list="linted_output/file_list.txt"
+          linted_failed_file=$(mktemp)
+          echo 0 > "$linted_failed_file"
+          find . -type f -name '*.md' | while read -r file; do
+            set +e
+            zhlint "$file"
+            if [ $? -ne 0 ]; then
+              echo 1 > "$linted_failed_file"
+              echo "$file" >> "$file_list"
+              output_file="linted_output/report_and_suggested_fixes/$file"
+              mkdir -p "$(dirname "$output_file")"
+              zhlint "$file" --output="$output_file" > "$output_file.log" 2>&1
+            fi
+            set -e
+          done
+          linted_failed=$(cat "$linted_failed_file")
+          rm "$linted_failed_file"
+          echo "linted_failed=$linted_failed" >> "$GITHUB_ENV"
+
+      - name: Upload linted Markdown
+        uses: actions/upload-artifact@v4
+        with:
+          name: linted-markdown
+          path: linted_output/
+
+      - name: Check lint errors
+        run: |
+          set -e
+          if [ "${{ env.linted_failed }}" -ne 0 ]; then
+            echo "Linting errors found. Please check the reports and suggested fixes in uploaded artifact."
+            exit 1
+          fi

--- a/.github/workflows/lint-all.yaml
+++ b/.github/workflows/lint-all.yaml
@@ -21,13 +21,13 @@ jobs:
           echo 0 > "$linted_failed_file"
           find . -type f -name '*.md' | while read -r file; do
             set +e
-            zhlint "$file"
+            zhlint --config "$GITHUB_WORKSPACE"/.scripts/.zhlintrc "$file"
             if [ $? -ne 0 ]; then
               echo 1 > "$linted_failed_file"
               echo "$file" >> "$file_list"
               output_file="linted_output/report_and_suggested_fixes/$file"
               mkdir -p "$(dirname "$output_file")"
-              zhlint "$file" --output="$output_file" > "$output_file.log" 2>&1
+              zhlint --config "$GITHUB_WORKSPACE"/.scripts/.zhlintrc "$file" --output="$output_file" > "$output_file.log" 2>&1
             fi
             set -e
           done

--- a/.scripts/.zhlintrc
+++ b/.scripts/.zhlintrc
@@ -1,0 +1,6 @@
+{
+  "preset": "default",
+  "rules": {
+    "halfwidthPunctuation": "（），。、"
+  }
+}


### PR DESCRIPTION
#240 

This workflow allows for manual triggering and checks all Markdown files in the repository for linting issues, providing reports and suggested fixes for any errors found. It will generate an artifact with zhlint log and autofix files

Test run:

- [Lint All #1](https://github.com/inscripoem/TranslateProject/actions/runs/12015369541) in inscripoem/TranslateProject

There might be still a bug in `zhlint` package which will cause failed linting for some articles. But we can check other articles before it is fixed.