### PR TITLE
ci: add workflow for closing stale PRs

### DIFF
--- a/.github/workflows/close-stale-pr.yml
+++ b/.github/workflows/close-stale-pr.yml
@@ -1,7 +1,7 @@
 name: 'Close stale PR'
 on:
   schedule:
-    - cron: '0 4 * * *' 
+    - cron: '0 20 * * *' 
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/close-stale-pr.yml
+++ b/.github/workflows/close-stale-pr.yml
@@ -1,0 +1,16 @@
+name: 'Close stale PR'
+on:
+  schedule:
+    - cron: '0 4 * * *' 
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9.1.0
+        with:
+          days-before-stale: -1 # only close prs
+          days-before-close: -1 # only close prs
+          days-before-pr-stale: 90 
+          days-before-pr-close: 7 
+          stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove the "Stale" label or add a comment, or this PR will be closed in 7 days.'
+          close-pr-message: 'This PR was closed because it was stale for 7 days with no activity.'


### PR DESCRIPTION
This workflow will check for stale PRs every day at 4:00 CST.

PRs that are inactive for 90 days will be marked as stale and removed after 7 days if no activity since then.

**No check will run for stale issues.**