### PR TITLE
feat(workflow): 新增检查 PR 中 Markdown 翻译状态的 GitHub 工作流

### DIFF
--- a/.github/workflows/check-pr-md-files.yml
+++ b/.github/workflows/check-pr-md-files.yml
@@ -1,0 +1,277 @@
+# =============================================
+# 📅 工作流名称：检查 PR 中的 Markdown 文件翻译状态
+# ✅ 每天 UTC 10:00 自动扫描 + 支持手动触发
+# ✅ 检查 sources/**/*.md 是否 status: translating 且超期（30天）
+# ✅ 超期则通过 curl 直接发送飞书卡片（无 Python 依赖）
+# =============================================
+
+name: Check PRs for Modified Markdown Files
+
+on:
+  schedule:
+    - cron: '0 10 * * *'  # 每天 UTC 10:00
+  workflow_dispatch:       # 允许手动触发
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  check-prs:
+    runs-on: ubuntu-latest
+    steps:
+
+      # 🧱 步骤 1：检出代码
+      - name: 🔍 Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # 📦 步骤 2：安装 yq（仅用于解析 YAML）
+      - name: 📦 Install yq
+        run: |
+          wget -q https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+
+      # ✅ 步骤 3：验证 yq
+      - name: ✅ Verify yq
+        run: yq --version
+
+      # 📋 步骤 4：列出所有 open PR
+      - name: 📋 List open pull requests
+        id: list_prs
+        run: |
+          PRS=$(gh api --paginate \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/${{ github.repository }}/pulls?state=open&per_page=100" \
+            --jq '[.[].number] | join(" ")')
+          if [ -z "$PRS" ]; then
+            echo "📭 没有找到任何 open PR"
+            echo "prs=" >> $GITHUB_OUTPUT
+          else
+            echo "📬 找到以下 PR: $PRS"
+            echo "prs=$PRS" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # 🔍 步骤 5：遍历每个 PR，检查超期文件（纯 Shell + curl）
+      - name: 🔍 Process each PR and send Feishu alert via curl
+        if: ${{ steps.list_prs.outputs.prs != '' }}
+        run: |
+          # 设置超期阈值（单位：天）
+          TIMEOUT_DAYS=30
+
+          # 创建安全临时目录
+          TEMP_DIR=$(mktemp -d)
+          trap 'rm -rf "$TEMP_DIR"' EXIT
+
+          # 🔄 遍历所有 PR 编号
+          for pr_number in ${{ steps.list_prs.outputs.prs }}; do
+            echo ""
+            echo "=== 🚀 正在检查 PR #$pr_number ==="
+
+            # 🌐 获取 PR 详细信息
+            PR_INFO=$(gh api "/repos/${{ github.repository }}/pulls/$pr_number")
+            PR_URL=$(echo "$PR_INFO" | jq -r '.html_url // "https://github.com/${{ github.repository }}/pull/'$pr_number'"')
+            PR_TITLE=$(echo "$PR_INFO" | jq -r '.title // "无标题"')
+            PR_AUTHOR=$(echo "$PR_INFO" | jq -r '.user.login // "未知"')
+            BASE_REF=$(echo "$PR_INFO" | jq -r '.base.ref // "main"')
+
+            echo "📌 标题: $PR_TITLE"
+            echo "👤 作者: @$PR_AUTHOR"
+            echo "🎯 目标分支: $BASE_REF"
+
+            # 🧬 获取 PR 合并预览
+            git fetch origin "pull/$pr_number/merge:pr_merge_$pr_number" 2>/dev/null || {
+              echo "⚠️ 无法获取 PR 合并预览，可能冲突或尚未准备好。跳过此 PR。"
+              echo "------------------------------"
+              continue
+            }
+            git checkout pr_merge_$pr_number
+
+            # 📄 检查是否修改了 sources/**/*.md
+            CHANGED_MD_FILES=$(git diff --name-only "origin/$BASE_REF..HEAD" | grep '^sources/.*\.md$' || true)
+
+            if [ -z "$CHANGED_MD_FILES" ]; then
+              echo "✅ PR #$pr_number 未修改 sources/**/*.md 文件，跳过检查"
+              echo "------------------------------"
+              continue
+            fi
+
+            echo "📝 PR #$pr_number 修改了以下 Markdown 文件："
+            echo "$CHANGED_MD_FILES"
+
+            # 📖 收集超期文件（构造卡片内容）
+            ITEMS=()
+            HAS_ERROR=false
+
+            while IFS= read -r file; do
+              SAFE_FILE=$(realpath -m "$file" 2>/dev/null)
+              if [[ ! "$SAFE_FILE" =~ ^$PWD/ ]]; then
+                echo "⚠️ 路径越权: $file"
+                continue
+              fi
+
+              if [ ! -f "$SAFE_FILE" ]; then
+                echo "⚠️ 文件不存在: $file"
+                continue
+              fi
+
+              # 🧾 提取 YAML Front Matter
+              FRONT_MATTER=$(sed -n '/^---$/,/^---$/{/^---$/!p}' "$SAFE_FILE" 2>/dev/null)
+              if [ -z "$FRONT_MATTER" ]; then
+                echo "⚠️ $file 没有 YAML Front Matter"
+                continue
+              fi
+
+              # 🗃️ 创建临时 YAML 文件
+              TEMP_YAML="$TEMP_DIR/frontmatter_$$.yaml"
+              echo "$FRONT_MATTER" > "$TEMP_YAML"
+
+              # 🎯 提取字段
+              STATUS=$(yq eval '.status // ""' "$TEMP_YAML" 2>/dev/null)
+              TRANSLATING_DATE=$(yq eval '.translating_date // ""' "$TEMP_YAML" 2>/dev/null)
+
+              # 🔍 只检查 status: translating
+              if [ "$STATUS" = "translating" ]; then
+                if [ -z "$TRANSLATING_DATE" ]; then
+                  ITEM=$(printf '{"文件":"%s","超期":"缺少 translating_date 字段","PR链接":"%s","作者":"%s"}' \
+                    "$(printf '%s' "$file" | sed 's/"/\\"/g')" \
+                    "$(printf '%s' "$PR_URL" | sed 's/"/\\"/g')" \
+                    "$(printf '%s' "@$PR_AUTHOR" | sed 's/"/\\"/g')")
+                  ITEMS+=("$ITEM")
+                  HAS_ERROR=true
+                  echo "❌ $file: 缺少 translating_date 字段"
+                else
+                  # 📅 容错解析日期
+                  DATE_STR=$(echo "$TRANSLATING_DATE" | sed 's|/|-|g')
+                  if ! TRANSLATING_TS=$(date -d "$DATE_STR" +%s 2>/dev/null); then
+                    ITEM=$(printf '{"文件":"%s","超期":"日期格式错误: %s","PR链接":"%s","作者":"%s"}' \
+                      "$(printf '%s' "$file" | sed 's/"/\\"/g')" \
+                      "$(printf '%s' "$TRANSLATING_DATE" | sed 's/"/\\"/g')" \
+                      "$(printf '%s' "$PR_URL" | sed 's/"/\\"/g')" \
+                      "$(printf '%s' "@$PR_AUTHOR" | sed 's/"/\\"/g')")
+                    ITEMS+=("$ITEM")
+                    HAS_ERROR=true
+                    echo "❌ $file: translating_date 格式错误: '$TRANSLATING_DATE'"
+                  else
+                    TODAY_TS=$(date +%s)
+                    DAY_DIFF=$(( (TODAY_TS - TRANSLATING_TS) / 86400 ))
+                    if [ $DAY_DIFF -gt $TIMEOUT_DAYS ]; then
+                      EMOJI="🚨"
+                      ITEM=$(printf '{"文件":"%s","超期":"%s %d 天前 (%s)","PR链接":"%s","作者":"%s","_days":%d}' \
+                        "$(printf '%s' "$file" | sed 's/"/\\"/g')" \
+                        "$EMOJI" \
+                        $DAY_DIFF \
+                        "$DATE_STR" \
+                        "$(printf '%s' "$PR_URL" | sed 's/"/\\"/g')" \
+                        "$(printf '%s' "@$PR_AUTHOR" | sed 's/"/\\"/g')" \
+                        $DAY_DIFF)
+                      ITEMS+=("$ITEM")
+                      HAS_ERROR=true
+                      echo "🚨 $file: translating_date 超过 $TIMEOUT_DAYS 天（$DAY_DIFF 天前）"
+                    else
+                      echo "✅ $file: translating_date 在 $TIMEOUT_DAYS 天内（$DAY_DIFF 天前）"
+                    fi
+                  fi
+                fi
+              else
+                echo "ℹ️ $file: status 不是 'translating'，跳过检查"
+              fi
+
+            done <<< "$CHANGED_MD_FILES"
+
+            # 🚨 如果有超期文件，用 curl 发送飞书卡片
+            if [ "$HAS_ERROR" = true ]; then
+              echo "🚨 此 PR 存在元数据问题，准备发送飞书通知..."
+
+              # 🧹 排序（按 _days 倒序）
+              if [ ${#ITEMS[@]} -gt 0 ]; then
+                SORT_FILE="$TEMP_DIR/sort_$$.txt"
+                for item in "${ITEMS[@]}"; do
+                  days=$(echo "$item" | sed -n 's/.*"_days":\([0-9]*\).*/\1/p')
+                  days=${days:-0}
+                  printf '%06d %s\n' $((999999 - days)) "$item"
+                done > "$SORT_FILE"
+
+                # 构造卡片 elements
+                ELEMENTS="[
+                  {
+                    \"tag\": \"div\",
+                    \"text\": {
+                      \"tag\": \"lark_md\",
+                      \"content\": \"**📄 PR 标题**: $PR_TITLE\\n**👤 作者**: @$PR_AUTHOR\\n\\n**⚠️ 以下文件翻译状态已超期，请及时处理**\"
+                    }
+                  }"
+
+                while IFS= read -r line; do
+                  json_part=${line#* }
+                  # ✅ 使用 ["字段"] 语法读取中文字段
+                  FILE=$(echo "$json_part" | jq -r '.["文件"]')
+                  OVERDUE=$(echo "$json_part" | jq -r '.["超期"]')
+                  PR_LINK=$(echo "$json_part" | jq -r '.["PR链接"]')
+                  AUTHOR=$(echo "$json_part" | jq -r '.["作者"]')
+
+                  # 构造一个 div 元素
+                  ELEMENTS="$ELEMENTS,
+                  {
+                    \"tag\": \"div\",
+                    \"text\": {
+                      \"tag\": \"lark_md\",
+                      \"content\": \"文件: $FILE\\n超期: $OVERDUE\\nPR链接: [🔗 查看详情]($PR_LINK)\\n作者: $AUTHOR\"
+                    }
+                  }"
+                done < <(sort -k1,1 "$SORT_FILE")
+
+                ELEMENTS="$ELEMENTS
+                ]"
+              else
+                ELEMENTS="[
+                  {
+                    \"tag\": \"div\",
+                    \"text\": {
+                      \"tag\": \"lark_md\",
+                      \"content\": \"无数据\"
+                    }
+                  }
+                ]"
+              fi
+
+              # 🎨 构造完整卡片 JSON
+              CARD_JSON=$(jq -n \
+                --arg title "🚨 翻译超期提醒 [PR #$pr_number]" \
+                --arg color "red" \
+                --argjson elements "$ELEMENTS" \
+                '{
+                  "config": {"wide_screen_mode": true},
+                  "header": {
+                    "template": $color,
+                    "title": {"content": $title, "tag": "plain_text"}
+                  },
+                  "elements": $elements
+                }')
+
+              # 📤 用 curl 发送
+              echo "📤 正在发送飞书卡片..."
+              RESPONSE=$(curl -s -X POST \
+                -H "Content-Type: application/json" \
+                -d "{\"msg_type\": \"interactive\", \"card\": $CARD_JSON}" \
+                "$FEISHU_WEBHOOK_URL")
+
+              # 🧪 检查响应
+              if echo "$RESPONSE" | jq -e '.code == 0' >/dev/null 2>&1; then
+                echo "✅ 飞书通知已发送。"
+              else
+                echo "❌ 发送失败: $RESPONSE"
+              fi
+            else
+              echo "🎉 此 PR 所有 Markdown 文件元数据符合规范！"
+            fi
+
+            echo "------------------------------"
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}


### PR DESCRIPTION
新增一个每日自动运行的 GitHub Actions 工作流，用于检查所有开放 PR 中修改的
Markdown 文件是否含有 `status: translating` 且翻译时间已超过 30 天。若检测到 超期文件，则通过飞书 Webhook 发送通知卡片，提醒及时处理。


相关 ISSUE

https://github.com/hust-open-atom-club/TranslateProject/issues/80
https://github.com/hust-open-atom-club/TranslateProject/issues/212

该工作流支持手动触发，并使用纯 Shell 脚本实现，不依赖 Python 环境。同时具备
YAML Front Matter 解析、日期容错处理与路径安全校验等健壮性设计。

需要在 Actions secrets  中设置飞书 webhook url 才能正常运行

效果以及对应 PR 仓库

https://github.com/zerokaze420/TranslateProject/pulls


<img width="604" height="273" alt="image" src="https://github.com/user-attachments/assets/4abe1c56-7e02-4ab8-b733-e5f3ba343750" />



