### PR TITLE
feat(check): 增强文章文件名校验与元数据检查逻辑

### DIFF
--- a/.scripts/check.sh
+++ b/.scripts/check.sh
@@ -2,170 +2,185 @@
 
 # Get valid files in git diff (markdown files in sources/)
 get_diff_article_files() {
-  FILES=$(cat $DIFF_JSON | yq e '.files[].path' - )
-  ARTICLES=''
-  for FILE in $FILES; do
-    if [[ "$FILE" == sources/*.md ]]; then # Seems duplicated with action path filter, keeping for safety
-      ARTICLES="$ARTICLES $FILE"
-    fi
-  done
-  if [ -z "$ARTICLES" ]; then
-    echo "No valid articles found in the PR. Skip checks."
-    exit 0
-  fi
-}
+    local FILENAME_SLUG_REGEX='^[a-z]+(-[a-z]+)*$'
+    FILES=$(jq -r '.files[].path' "$DIFF_JSON") 
+    ARTICLES=''
+    for FILE in $FILES; do
+        if [[ "$FILE" == sources/*.md ]]; then 
+            
+            # 1. 提取文件名主体 (e.g., 从 sources/my-article.md 得到 my-article.md)
+            BASENAME=$(basename "$FILE")
+            
+            # 2. 移除 .md 扩展名，得到 slug (e.g., 从 my-article.md 得到 my-article)
+            SLUG=${BASENAME%.md}
 
+            # 3. 执行正则匹配
+            if [[ "$SLUG" =~ $FILENAME_SLUG_REGEX ]]; then
+                ARTICLES="$ARTICLES $FILE"
+            else
+                ERROR=$ERROR"⚠️ Warning: Body '$SLUG' of filename '$FILE' does not meet requirements /^[a-z]+(-[a-z]+)*$/, skipping the check." >&2
+                echo $ERROR
+                exit 1
+            fi
+            
+        fi
+    done
+    if [ -z "$ARTICLES" ]; then
+        echo "No valid articles found in the PR. Skip checks."
+        exit 0
+
+    fi
+}
 # Check if published_date is in the front matter
 check_published() {
-  PUBLISHED_ARTICLE=$1
-  PUBLISHER=$(yq -f extract '.publisher' $PUBLISHED_ARTICLE)
-  PUBLISHED_DATE=$(yq -f extract '.published_date' $PUBLISHED_ARTICLE)
-  if [ "$PUBLISHER" == "null" ] || [ "$PUBLISHED_DATE" == "null" ]; then
-    ERROR=$ERROR"Missing metadata in publisher/published_date; "
-  # Comment this check since it's good to give a last chance for people
-  # to fix some minor issues missed in the previous stages
-  # else
-  #   # No stage check needed for the final stage
-  #   if [ "$PUBLISHER" != "$ACTOR_ID" ]; then
-  #     ERROR=$ERROR"Publisher is not the same as the PR opener; "
-  #   fi
-  fi
+    PUBLISHED_ARTICLE=$1
+    PUBLISHER=$(yq -f extract '.publisher' $PUBLISHED_ARTICLE)
+    PUBLISHED_DATE=$(yq -f extract '.published_date' $PUBLISHED_ARTICLE)
+    if [ "$PUBLISHER" == "null" ] || [ "$PUBLISHED_DATE" == "null" ]; then
+        ERROR=$ERROR"Missing metadata in publisher/published_date; "
+    # Comment this check since it's good to give a last chance for people
+    # to fix some minor issues missed in the previous stages
+    # else
+    #    # No stage check needed for the final stage
+    #    if [ "$PUBLISHER" != "$ACTOR_ID" ]; then
+    #       ERROR=$ERROR"Publisher is not the same as the PR opener; "
+    #    fi
+    fi
 }
 
 # Check if proofread_date is in the front matter
 check_proofread() {
-  PROOFREAD_ARTICLE=$1
-  PROOFREAD_DATE=$(yq -f extract '.proofread_date' $PROOFREAD_ARTICLE)
-  if [ "$PROOFREAD_DATE" == "null" ]; then
-    ERROR=$ERROR"Missing metadata in proofread_date; "
-  else
-    # Check if proofread_date is earlier than published_date
-    PUBLISHED_DATE=$(yq -f extract '.published_date' $PROOFREAD_ARTICLE)
-    if [ ! $PUBLISHED_DATE == "null" ] && [ $PUBLISHED_DATE -lt $PROOFREAD_DATE ]; then
-      ERROR=$ERROR"Published date is earlier than proofread date; "
+    PROOFREAD_ARTICLE=$1
+    PROOFREAD_DATE=$(yq -f extract '.proofread_date' $PROOFREAD_ARTICLE)
+    if [ "$PROOFREAD_DATE" == "null" ]; then
+        ERROR=$ERROR"Missing metadata in proofread_date; "
+    else
+        # Check if proofread_date is earlier than published_date
+        PUBLISHED_DATE=$(yq -f extract '.published_date' $PROOFREAD_ARTICLE)
+        if [ ! $PUBLISHED_DATE == "null" ] && [ $PUBLISHED_DATE -lt $PROOFREAD_DATE ]; then
+            ERROR=$ERROR"Published date is earlier than proofread date; "
+        fi
     fi
-  fi
 }
 
 # Check if proofreader is in the front matter for proofreading/proofread stage,
 # and check if proofreader is the same as the PR opener in proofreading/proofread stage
 check_proofreading() {
-  PROOFREADING_ARTICLE=$1
-  PROOFREADER=$(yq -f extract '.proofreader' $PROOFREADING_ARTICLE)
-  if [ "$PROOFREADER" == "null" ]; then
-    ERROR=$ERROR"Missing metadata in proofreader; "
-  else
-    if [ "$STATUS" == "proofreading" ] || [ "$STATUS" == "proofread" ]; then
-      if [ "$PROOFREADER" != "$ACTOR_ID" ]; then
-        ERROR=$ERROR"Proofreader is not the same as the PR opener; "
-      fi
+    PROOFREADING_ARTICLE=$1
+    PROOFREADER=$(yq -f extract '.proofreader' $PROOFREADING_ARTICLE)
+    if [ "$PROOFREADER" == "null" ]; then
+        ERROR=$ERROR"Missing metadata in proofreader; "
+    else
+        if [ "$STATUS" == "proofreading" ] || [ "$STATUS" == "proofread" ]; then
+            if [ "$PROOFREADER" != "$ACTOR_ID" ]; then
+                ERROR=$ERROR"Proofreader is not the same as the PR opener; "
+            fi
+        fi
     fi
-  fi
 }
 
 # Check if translated_date is in the front matter
 check_translated() {
-  TRANSLATED_ARTICLE=$1
-  TRANSLATED_DATE=$(yq -f extract '.translated_date' $TRANSLATED_ARTICLE)
-  if [ "$TRANSLATED_DATE" == "null" ]; then
-    ERROR=$ERROR"Missing metadata in translated_date; "
-  else
-    # Check if translated_date is earlier than proofread_date
-    PROOFREAD_DATE=$(yq -f extract '.proofread_date' $TRANSLATED_ARTICLE)
-    if [ ! $PROOFREAD_DATE == "null" ] && [ $PROOFREAD_DATE -lt $TRANSLATED_DATE ]; then
-      ERROR=$ERROR"Proofread date is earlier than translated date; "
+    TRANSLATED_ARTICLE=$1
+    TRANSLATED_DATE=$(yq -f extract '.translated_date' $TRANSLATED_ARTICLE)
+    if [ "$TRANSLATED_DATE" == "null" ]; then
+        ERROR=$ERROR"Missing metadata in translated_date; "
+    else
+        # Check if translated_date is earlier than proofread_date
+        PROOFREAD_DATE=$(yq -f extract '.proofread_date' $TRANSLATED_ARTICLE)
+        if [ ! $PROOFREAD_DATE == "null" ] && [ $PROOFREAD_DATE -lt $TRANSLATED_DATE ]; then
+            ERROR=$ERROR"Proofread date is earlier than translated date; "
+        fi
     fi
-  fi
 }
 
 # Check if translator is in the front matter for translating/translated stage,
 # and check if translator is the same as the PR opener in translating/translated stage
 check_translating() {
-  TRANSLATING_ARTICLE=$1
-  TRANSLATOR=$(yq -f extract '.translator' $TRANSLATING_ARTICLE)
-  TRANSLATING_DATE=$(yq -f extract '.translating_date' $TRANSLATING_ARTICLE)
-  if [ "$TRANSLATOR" == "null" ]; then
-    ERROR=$ERROR"Missing metadata in translator; "
-  else
-    if [ "$STATUS" == "translating" ] || [ "$STATUS" == "translated" ]; then
-      COLLECTED_DATE=$(yq -f extract '.collected_date' $TRANSLATING_ARTICLE)
-      if [ ! $TRANSLATING_DATE == "null" ] && [ $TRANSLATING_DATE -lt $COLLECTED_DATE ]; then
-        ERROR=$ERROR"Translating date is earlier than collected date;"
-      elif [ "$TRANSLATOR" != "$ACTOR_ID" ]; then
-        ERROR=$ERROR"Translator is not the same as the PR opener; "
-      fi
+    TRANSLATING_ARTICLE=$1
+    TRANSLATOR=$(yq -f extract '.translator' $TRANSLATING_ARTICLE)
+    TRANSLATING_DATE=$(yq -f extract '.translating_date' $TRANSLATING_ARTICLE)
+    if [ "$TRANSLATOR" == "null" ]; then
+        ERROR=$ERROR"Missing metadata in translator; "
+    else
+        if [ "$STATUS" == "translating" ] || [ "$STATUS" == "translated" ]; then
+            COLLECTED_DATE=$(yq -f extract '.collected_date' $TRANSLATING_ARTICLE)
+            if [ ! $TRANSLATING_DATE == "null" ] && [ $TRANSLATING_DATE -lt $COLLECTED_DATE ]; then
+                ERROR=$ERROR"Translating date is earlier than collected date;"
+            elif [ "$TRANSLATOR" != "$ACTOR_ID" ]; then
+                ERROR=$ERROR"Translator is not the same as the PR opener; "
+            fi
+        fi
     fi
-  fi
 }
 
 # Check if collected_date, collector, title, and author are in the front matter,
 # and check if collector is the same as the PR opener in collected stage
 check_collected() {
-  COLLECTED_ARTICLE=$1
-  TITLE=$(yq -f extract '.title' $COLLECTED_ARTICLE)
-  AUTHOR=$(yq -f extract '.author' $COLLECTED_ARTICLE)
-  COLLECTOR=$(yq -f extract '.collector' $COLLECTED_ARTICLE)
-  COLLECTED_DATE=$(yq -f extract '.collected_date' $COLLECTED_ARTICLE)
-  LINK=$(yq -f extract '.link' $COLLECTED_ARTICLE)
-  if [ "$TITLE" == "null" ] || [ "$AUTHOR" == "null" ] || [ "$COLLECTOR" == "null" ] || [ "$COLLECTED_DATE" == "null" ] || [ "$LINK" == "null" ]; then
-    ERROR=$ERROR"Missing metadata in title/author/collector/collected_date/link; "
-  else
-    # Check if collected_date is earlier than translated_date
-    TRANSLATED_DATE=$(yq -f extract '.translated_date' $COLLECTED_ARTICLE)
-    if [ ! $TRANSLATED_DATE == "null" ] && [ $TRANSLATED_DATE -lt $COLLECTED_DATE ]; then
-      ERROR=$ERROR"Translated date is earlier than collected date; "
+    COLLECTED_ARTICLE=$1
+    TITLE=$(yq -f extract '.title' $COLLECTED_ARTICLE)
+    AUTHOR=$(yq -f extract '.author' $COLLECTED_ARTICLE)
+    COLLECTOR=$(yq -f extract '.collector' $COLLECTED_ARTICLE)
+    COLLECTED_DATE=$(yq -f extract '.collected_date' $COLLECTED_ARTICLE)
+    LINK=$(yq -f extract '.link' $COLLECTED_ARTICLE)
+    if [ "$TITLE" == "null" ] || [ "$AUTHOR" == "null" ] || [ "$COLLECTOR" == "null" ] || [ "$COLLECTED_DATE" == "null" ] || [ "$LINK" == "null" ]; then
+        ERROR=$ERROR"Missing metadata in title/author/collector/collected_date/link; "
+    else
+        # Check if collected_date is earlier than translated_date
+        TRANSLATED_DATE=$(yq -f extract '.translated_date' $COLLECTED_ARTICLE)
+        if [ ! $TRANSLATED_DATE == "null" ] && [ $TRANSLATED_DATE -lt $COLLECTED_DATE ]; then
+            ERROR=$ERROR"Translated date is earlier than collected date; "
+        fi
+        if [ "$STATUS" == "collected" ]; then
+            if [ "$COLLECTOR" != "$ACTOR_ID" ]; then
+                ERROR=$ERROR"Collector is not the same as the PR opener; "
+            fi
+        fi
     fi
-    if [ "$STATUS" == "collected" ]; then
-      if [ "$COLLECTOR" != "$ACTOR_ID" ]; then
-        ERROR=$ERROR"Collector is not the same as the PR opener; "
-      fi
-    fi
-  fi
 }
 
 CHECK_PASSED=1 # To check if all the articles pass
 get_diff_article_files
 for ARTICLE in $ARTICLES; do
-  echo "Checking article: $ARTICLE"
-  ERROR=""
-  STATUS=$(yq -f extract '.status' $ARTICLE)
-  case $STATUS in
-    "published")
-      check_published $ARTICLE
-      ;& # Fallthrough to ensure low stage checks will run on articles in higher stages
-    "proofread")
-      check_proofread $ARTICLE
-      ;&
-    "proofreading")
-      check_proofreading $ARTICLE
-      ;&
-    "translated")
-      check_translated $ARTICLE
-      ;&
-    "translating")
-      check_translating $ARTICLE
-      ;&
-    "collected")
-      check_collected $ARTICLE
-      ;;
-    *)
-      ERROR="Invalid status: $STATUS"
-      ;;
-  esac
-  # Printlog for each article
-  if [ -z "$ERROR" ]; then
-    echo "  ✨ All checks passed for $STATUS $ARTICLE"
-  else
-    echo "  😭 Some checks failed for $STATUS $ARTICLE: $ERROR"
-    CHECK_PASSED=0
-  fi
+    echo "Checking article: $ARTICLE"
+    ERROR=""
+    STATUS=$(yq -f extract '.status' $ARTICLE)
+    case $STATUS in
+        "published")
+            check_published $ARTICLE
+            ;& # Fallthrough to ensure low stage checks will run on articles in higher stages
+        "proofread")
+            check_proofread $ARTICLE
+            ;&
+        "proofreading")
+            check_proofreading $ARTICLE
+            ;&
+        "translated")
+            check_translated $ARTICLE
+            ;&
+        "translating")
+            check_translating $ARTICLE
+            ;&
+        "collected")
+            check_collected $ARTICLE
+            ;;
+        *)
+            ERROR="Invalid status: $STATUS"
+            ;;
+    esac
+    # Printlog for each article
+    if [ -z "$ERROR" ]; then
+        echo "  ✨ All checks passed for $STATUS $ARTICLE"
+    else
+        echo "  😭 Some checks failed for $STATUS $ARTICLE: $ERROR"
+        CHECK_PASSED=0
+    fi
 done
 # Print overall result
 if [ $CHECK_PASSED -eq 0 ]; then
-  echo "❌ Some checks failed. Please fix the article(s) before merging the PR."
-  exit 1
+    echo "❌ Some checks failed. Please fix the article(s) before merging the PR."
+    exit 1
 else
-  echo "✅ All checks passed. You can merge the PR now."
-  exit 0
+    echo "✅ All checks passed. You can merge the PR now."
+    exit 0
 fi
-


### PR DESCRIPTION
https://github.com/zerokaze420/TranslateProject/actions/runs/18069137733/job/51416580238?pr=9
https://github.com/zerokaze420/TranslateProject/actions/runs/18069159019/job/51416981919

- 使用 jq 替代 yq 来解析 diff 文件列表，提高兼容性
- 引入文件名规范校验（slug 格式：小写字母和连字符组成）
- 完善各类状态下的元数据字段检查逻辑，包括 published、proofread、 translating、collected 等阶段
- 改进错误提示信息，确保在不合规时能够准确提示并终止流程
- 优化脚本结构和缩进，提升可读性和维护性

